### PR TITLE
feat: Add Beets & Origin API for Sonic staking

### DIFF
--- a/adapters/sonic/beets/index.ts
+++ b/adapters/sonic/beets/index.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import { Logger } from 'tslog';
+import { autoInjectable } from 'tsyringe';
+import type { IYieldAdapter } from '../../../types/adapter.d.ts';
+import type { TBeetsStakedSonicMarket, TBeetsStakedSonicResponse } from './types.js';
+import { TChainName } from 'types/chains.js';
+import { TToken } from 'types/tokens.js';
+
+const BEETS_BASE_URL = 'https://backend-v3.beets-ftm-node.com/';
+
+@autoInjectable()
+export class BeetsApiAdapter implements IYieldAdapter {
+  name = 'sonic.BeetsApiAdapter';
+  logger = new Logger({ name: this.name });
+
+  stsMarket?: TBeetsStakedSonicMarket;
+
+  // TODO
+  fetchTokensWithYield(chain: TChainName, tokens: TToken[]) {
+    console.log(chain, tokens);
+  }
+
+  // Markets
+  async getStakedSonicMarket(): Promise<TBeetsStakedSonicMarket> {
+    try {
+      if (!this.stsMarket) {
+        const params = {
+          operationName: 'GetStakedSonicData',
+          variables: {},
+          query: `
+          query GetStakedSonicData {
+            stsGetGqlStakedSonicData {
+              delegatedValidators {
+                assetsDelegated
+                validatorId
+                __typename
+              }
+              exchangeRate
+              stakingApr
+              totalAssets
+              totalAssetsDelegated
+              totalAssetsPool
+              rewardsClaimed24h
+              __typename
+            }
+          }
+          `,
+        };
+        const res = await axios.post<TBeetsStakedSonicResponse>(`${BEETS_BASE_URL}`, params, {
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+          },
+        });
+        return res.data.data.stsGetGqlStakedSonicData;
+      }
+      return this.stsMarket;
+    } catch (error) {
+      throw new Error('Failed to get StakedSonic from Beets');
+    }
+  }
+}

--- a/adapters/sonic/beets/types.d.ts
+++ b/adapters/sonic/beets/types.d.ts
@@ -1,0 +1,22 @@
+export interface TBeetsStakedSonicResponse {
+  data: {
+    stsGetGqlStakedSonicData: TBeetsStakedSonicMarket;
+  };
+}
+
+export interface TBeetsStakedSonicMarket {
+  delegatedValidators: DelegatedValidator[];
+  exchangeRate: string;
+  stakingApr: string;
+  totalAssets: string;
+  totalAssetsDelegated: string;
+  totalAssetsPool: string;
+  rewardsClaimed24h: string;
+  __typename: string;
+}
+
+export interface DelegatedValidator {
+  assetsDelegated: string;
+  validatorId: string;
+  __typename: string;
+}

--- a/adapters/sonic/index.ts
+++ b/adapters/sonic/index.ts
@@ -1,4 +1,6 @@
 export * from './shadow/index.ts';
 export * from './metropolis/index.ts';
 export * from './silo/index.ts';
+export * from './beets/index.ts';
+export * from './origin/index.ts';
 export * from './paintswap/index.ts';

--- a/adapters/sonic/origin/index.ts
+++ b/adapters/sonic/origin/index.ts
@@ -1,0 +1,88 @@
+import axios from 'axios';
+import { Logger } from 'tslog';
+import { autoInjectable } from 'tsyringe';
+import type { IYieldAdapter } from '../../../types/adapter.d.ts';
+import type { TOriginSonicDailyStat, TOriginSonicResponse } from './types.js';
+import { TChainName } from 'types/chains.js';
+import { TToken } from 'types/tokens.js';
+
+const ORIGIN_BASE_URL = 'https://origin.squids.live/origin-squid:prod/api/graphql';
+
+@autoInjectable()
+export class OriginApiAdapter implements IYieldAdapter {
+  name = 'sonic.OriginApiAdapter';
+  logger = new Logger({ name: this.name });
+
+  osMarket?: TOriginSonicDailyStat;
+
+  // TODO
+  fetchTokensWithYield(chain: TChainName, tokens: TToken[]) {
+    console.log(chain, tokens);
+  }
+
+  // Markets
+  async getStakedSonicMarket(): Promise<TOriginSonicDailyStat> {
+    try {
+      if (!this.osMarket) {
+        const params = {
+          variables: {
+            chainId: 146, // Sonic
+            token: '0xb1e25689d55734fd3fffc939c4c3eb52dff8a794', // Sonic
+            limit: 1,
+            orderBy: ['timestamp_DESC'],
+          },
+          query: `
+          query oTokenStats(
+            $token: String!
+            $chainId: Int!
+            $limit: Int = 5000
+            $orderBy: [OTokenDailyStatOrderByInput!] = [timestamp_DESC]
+            $from: DateTime
+            $offset: Int = 1
+          ) {
+            oTokenDailyStats(
+              limit: $limit
+              offset: $offset
+              orderBy: $orderBy
+              where: { otoken_eq: $token, chainId_eq: $chainId, timestamp_gte: $from }
+            ) {
+              ...DailyStat
+            }
+          }
+          fragment DailyStat on OTokenDailyStat {
+            id
+            blockNumber
+            timestamp
+            date
+            totalSupply
+            apy
+            apy7
+            apy14
+            apy30
+            rateETH
+            rateUSD
+            rebasingSupply
+            nonRebasingSupply
+            wrappedSupply
+            amoSupply
+            yield
+            fees
+            dripperWETH
+          }
+          `,
+        };
+        const res = await axios.post<TOriginSonicResponse>(`${ORIGIN_BASE_URL}`, params, {
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+          },
+        });
+        return res.data.data.oTokenDailyStats[0];
+      }
+      return this.osMarket;
+    } catch (error) {
+      throw new Error('Failed to get Sonic LST from Origin');
+    }
+  }
+}

--- a/adapters/sonic/origin/types.d.ts
+++ b/adapters/sonic/origin/types.d.ts
@@ -1,0 +1,26 @@
+export interface TOriginSonicResponse {
+  data: {
+    oTokenDailyStats: TOriginSonicDailyStat[];
+  };
+}
+
+export interface TOriginSonicDailyStat {
+  id: string;
+  blockNumber: number;
+  timestamp: Date;
+  date: Date;
+  totalSupply: string;
+  apy: number;
+  apy7: number;
+  apy14: number;
+  apy30: number;
+  rateETH: string;
+  rateUSD: string;
+  rebasingSupply: string;
+  nonRebasingSupply: string;
+  wrappedSupply: string;
+  amoSupply: string;
+  yield: string;
+  fees: string;
+  dripperWETH: string;
+}

--- a/examples/config.ts
+++ b/examples/config.ts
@@ -1,3 +1,4 @@
+import { BeetsApiAdapter } from 'adapters/sonic/beets/index.ts';
 import { rpc, adapters, ChainsmithSdk } from '../index.ts';
 import { EvmTokenPlugin } from '../plugins/evm/index.ts';
 import { alchemy } from '../rpc/index.ts';
@@ -31,6 +32,8 @@ export const AdapterRegistry = {
   PaintSwap: new adapters.PaintSwapAdapter(),
   MetropolisApi: new adapters.MetropolisApiAdapter(),
   SiloV2Api: new adapters.SiloV2ApiAdapter(),
+  BeetsApi: new adapters.BeetsApiAdapter(),
+  OriginApi: new adapters.OriginApiAdapter(),
 
   Reservoir: new adapters.ReservoirAdapter(RESERVOIR_API_KEY),
 };

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -94,11 +94,17 @@ async function fetchNFTData() {
 }
 
 async function fetchSonicDapp() {
-  const markets = await AdapterRegistry.SiloV2Api.getSiloMarkets();
-  console.log(markets[0]);
+  // const markets = await AdapterRegistry.SiloV2Api.getSiloMarkets();
+  // console.log(markets[0]);
 
-  const vaults = await AdapterRegistry.MetropolisApi.getVaults(146);
-  console.log(vaults[0]);
+  // const vaults = await AdapterRegistry.MetropolisApi.getVaults(146);
+  // console.log(vaults[0]);
+
+  const sts = await AdapterRegistry.BeetsApi.getStakedSonicMarket();
+  console.log(sts);
+
+  const os = await AdapterRegistry.OriginApi.getStakedSonicMarket();
+  console.log(os);
 }
 
 testExternalities(false, fetchMultichainTokenPortfolio);
@@ -107,5 +113,5 @@ testExternalities(false, fetchEvmscanTokenActivitiesWorks);
 testExternalities(false, fetchDexScreenerParis);
 testExternalities(false, fetchChainlistMetadata);
 testExternalities(false, fetchSonicChainData);
-testExternalities(true, fetchNFTData);
-testExternalities(false, fetchSonicDapp);
+testExternalities(false, fetchNFTData);
+testExternalities(true, fetchSonicDapp);


### PR DESCRIPTION
## Purpose
Get staking Sonic APY/APR from the current 2 LST protocols.

## Note
- Currently using REST to query GraphQL API :/

### Beets
Number from https://beets.fi/stake
```typescript
{   
    delegatedValidators: [...],
    exchangeRate: '1.011962267116420922',
    stakingApr: '0.04643374394917914',
    totalAssets: '154806454.395013569413252872',
    totalAssetsDelegated: '153035772.392717608469800186',
    totalAssetsPool: '1770682.002295960943452686',
    rewardsClaimed24h: '12707.68175808387',
    __typename: 'GqlStakedSonicData'
}
```

### Origin Protocol
Number from https://app.originprotocol.com/#/os/
```typescript
{   
    id: '146-0xb1e25689d55734fd3fffc939c4c3eb52dff8a794-2025-03-04',
    blockNumber: 11720700,
    timestamp: '2025-03-04T23:59:59.000000Z',
    date: '2025-03-04',
    totalSupply: '53298747018884613279858965',
    apy: 0.08545668500921022,
    apy7: 0.09628353713441351,
    apy14: 0.09122751213178423,
    apy30: 0.11705870721380952,
    rateETH: '259420449561656',
    rateUSD: '561933230000000000',
    rebasingSupply: '30919606803168911574903838',
    nonRebasingSupply: '22379140215715701704955127',
    wrappedSupply: '24995104633777312741546948',
    amoSupply: '0',
    yield: '6760441509642214115837',
    fees: '751160167738023790587',
    dripperWETH: '0'
}
```